### PR TITLE
chore: add Gradle to .mise.toml

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -6,3 +6,4 @@ node = "22.20.0"
 # backend
 java = "temurin-21.0.8+9"
 kotlin = "2.2.20"
+gradle = "9.1.0"


### PR DESCRIPTION
## Description
Add Gradle to `.mise.toml` so contributors get a consistent Gradle version via `mise install`.

## Changes
- Update `.mise.toml`
- No runtime code changes.

## How to Test
1. Run `mise install`
2. Verify Gradle is installed: `gradle --version`